### PR TITLE
Add server-side favorites endpoints and viewer hydration

### DIFF
--- a/docs/contract.md
+++ b/docs/contract.md
@@ -66,6 +66,7 @@ Vitest is the acceptance source for this contract. The Postman repo stays aligne
   - `stats.commentCount`
   - `stats.ratingCount`
   - `stats.averageRating`
+  - `isFavorited`
   - `distanceMiles` when geo filtering is active
 
 ### `GET /api/discover/home`
@@ -104,6 +105,7 @@ Vitest is the acceptance source for this contract. The Postman repo stays aligne
 - `topCategorySlugs` contains the top `1-2` canonical category slugs across the adventurer's public published adventures
 - `Popular Adventures` item shape:
   - same as `GET /api/feed`
+  - includes viewer-scoped `isFavorited`
 - `Popular Adventures` ordering:
   - favorite count descending
   - comment count descending
@@ -136,6 +138,7 @@ Vitest is the acceptance source for this contract. The Postman repo stays aligne
   - same as Discover adventurer shape from `GET /api/discover/home`
 - `adventures.items` shape:
   - same as `GET /api/feed`
+  - includes viewer-scoped `isFavorited`
 - `People` search matches:
   - `handle`
   - `displayName`
@@ -173,6 +176,36 @@ Vitest is the acceptance source for this contract. The Postman repo stays aligne
   - everything from the feed item shape
   - `updatedAt`
   - `placeLabel`
+
+### `POST /api/adventures/:id/favorite`
+
+- auth: required
+- params:
+  - `id`: UUID
+- any query param is rejected with `400`
+- response:
+  - `200` with `{ item }` when the visible published adventure is now favorited for the authenticated viewer
+  - `404` with `{ error: "Adventure not found." }` when missing or not visible
+  - `403` with `{ error: "Adventure favorites require a completed local account." }` when the bearer identity has no completed local viewer row
+- write behavior:
+  - idempotent; posting an existing favorite still succeeds
+- stable `item` shape:
+  - same as `GET /api/adventures/:id`
+
+### `DELETE /api/adventures/:id/favorite`
+
+- auth: required
+- params:
+  - `id`: UUID
+- any query param is rejected with `400`
+- response:
+  - `200` with `{ item }` when the visible published adventure is now not favorited for the authenticated viewer
+  - `404` with `{ error: "Adventure not found." }` when missing or not visible
+  - `403` with `{ error: "Adventure favorites require a completed local account." }` when the bearer identity has no completed local viewer row
+- write behavior:
+  - idempotent; deleting a missing favorite still succeeds
+- stable `item` shape:
+  - same as `GET /api/adventures/:id`
 
 ### `GET /api/adventures/:id/media`
 
@@ -231,6 +264,25 @@ Vitest is the acceptance source for this contract. The Postman repo stays aligne
   - `createdAt`
   - `updatedAt`
 - stable `adventures` item shape:
+  - same as `GET /api/feed`
+  - `placeLabel` remains `null` in the current authored-adventure payload
+
+### `GET /api/profiles/:handle/favorites`
+
+- auth: required
+- params:
+  - `handle`: non-empty string up to `64` chars
+- query:
+  - `limit`: integer, min `1`, max `50`, default `20`
+  - `offset`: integer, min `0`, default `0`
+- any extra query param is rejected with `400`
+- `viewerHandle` is rejected with `400`
+- response:
+  - `200` with `{ items, paging }`
+  - `403` with `{ error: "Forbidden." }` when `:handle` does not match the authenticated viewer handle
+- collection policy:
+  - only the authenticated viewer may read their own favorites collection
+- stable `items` shape:
   - same as `GET /api/feed`
 
 ### `GET /api/me/profile`

--- a/src/features/adventures/repository.ts
+++ b/src/features/adventures/repository.ts
@@ -1,9 +1,11 @@
 import { randomUUID } from "node:crypto";
 
-import type { PoolClient, QueryResultRow } from "pg";
+import type { PoolClient, QueryResult, QueryResultRow } from "pg";
 
 import { db } from "../../db/client.js";
 import { toApiAdventureVisibility } from "./visibility.js";
+
+type Queryable = PoolClient | typeof db;
 
 type AdventureFeedRow = QueryResultRow & {
   id: string;
@@ -27,6 +29,7 @@ type AdventureFeedRow = QueryResultRow & {
   average_rating: number | null;
   place_label: string | null;
   distance_miles: number | null;
+  is_favorited: boolean | null;
 };
 
 export type AdventureCard = {
@@ -58,6 +61,7 @@ export type AdventureCard = {
     ratingCount: number;
     averageRating: number;
   };
+  isFavorited: boolean;
   distanceMiles?: number;
 };
 
@@ -121,6 +125,22 @@ export type CreatedAdventure = {
   status: string;
 };
 
+function getExecutor(client?: PoolClient): Queryable {
+  return client ?? db;
+}
+
+async function runQuery<TResult extends QueryResultRow>(
+  client: PoolClient | undefined,
+  text: string,
+  values: unknown[]
+): Promise<QueryResult<TResult>> {
+  const executor = getExecutor(client) as {
+    query: (sql: string, params: unknown[]) => Promise<QueryResult<TResult>>;
+  };
+
+  return executor.query(text, values);
+}
+
 function mapAdventureCard(row: AdventureFeedRow): AdventureCard {
   const distanceMiles = row.distance_miles;
 
@@ -159,6 +179,7 @@ function mapAdventureCard(row: AdventureFeedRow): AdventureCard {
       ratingCount: row.rating_count ?? 0,
       averageRating: row.average_rating ?? 0
     },
+    isFavorited: row.is_favorited ?? false,
     ...(distanceMiles !== null && distanceMiles !== undefined ? { distanceMiles } : {})
   };
 }
@@ -207,7 +228,14 @@ const adventureBaseSelect = `
     adventure_stats.comment_count,
     adventure_stats.rating_count,
     adventure_stats.average_rating,
-    adventures.place_label
+    adventures.place_label,
+    exists (
+      select 1
+      from viewer
+      join public.adventure_favorites
+        on public.adventure_favorites.user_id = viewer.id
+      where public.adventure_favorites.adventure_id = adventures.id
+    ) as is_favorited
 `;
 
 const feedGeoSelect = `
@@ -232,6 +260,42 @@ const feedJoins = `
   left join public.adventure_stats adventure_stats
     on adventure_stats.adventure_id = adventures.id
 `;
+
+async function getVisibleAdventureById(
+  options: {
+    adventureId: string;
+    viewerId?: string;
+  },
+  client?: PoolClient
+): Promise<(AdventureCard & { placeLabel: string | null; updatedAt: string }) | null> {
+  const result = await runQuery<AdventureDetailRow>(
+    client,
+    `
+      with viewer as (
+        select $1::uuid as id
+      )
+      ${adventureBaseSelect},
+      adventures.updated_at::text as updated_at
+      ${feedJoins}
+      where adventures.id = $2::uuid
+        and adventures.status = 'published'
+        and ${visibilityClause()}
+      limit 1
+    `,
+    [options.viewerId ?? null, options.adventureId]
+  );
+
+  const row = result.rows[0];
+  if (!row) {
+    return null;
+  }
+
+  return {
+    ...mapAdventureCard(row),
+    placeLabel: row.place_label,
+    updatedAt: row.updated_at
+  };
+}
 
 export async function listFeed(options: {
   viewerId?: string;
@@ -308,32 +372,7 @@ export async function getAdventureById(options: {
   adventureId: string;
   viewerId?: string;
 }): Promise<(AdventureCard & { placeLabel: string | null; updatedAt: string }) | null> {
-  const result = await db.query<AdventureDetailRow>(
-    `
-      with viewer as (
-        select $1::uuid as id
-      )
-      ${adventureBaseSelect},
-      adventures.updated_at::text as updated_at
-      ${feedJoins}
-      where adventures.id = $2::uuid
-        and adventures.status = 'published'
-        and ${visibilityClause()}
-      limit 1
-    `,
-    [options.viewerId ?? null, options.adventureId]
-  );
-
-  const row = result.rows[0];
-  if (!row) {
-    return null;
-  }
-
-  return {
-    ...mapAdventureCard(row),
-    placeLabel: row.place_label,
-    updatedAt: row.updated_at
-  };
+  return getVisibleAdventureById(options);
 }
 
 export async function listAdventureMedia(options: {
@@ -470,4 +509,61 @@ export async function createAdventure(
     id: adventureResult.rows[0]!.id,
     status: adventureResult.rows[0]!.status
   };
+}
+
+export async function insertAdventureFavorite(
+  options: {
+    viewerId: string;
+    adventureId: string;
+  },
+  client?: PoolClient
+): Promise<(AdventureCard & { placeLabel: string | null; updatedAt: string }) | null> {
+  const visibleAdventure = await getVisibleAdventureById(options, client);
+  if (!visibleAdventure) {
+    return null;
+  }
+
+  await runQuery(
+    client,
+    `
+      insert into public.adventure_favorites (
+        user_id,
+        adventure_id,
+        created_at
+      ) values (
+        $1::uuid,
+        $2::uuid,
+        now()
+      )
+      on conflict (user_id, adventure_id) do nothing
+    `,
+    [options.viewerId, options.adventureId]
+  );
+
+  return getVisibleAdventureById(options, client);
+}
+
+export async function deleteAdventureFavorite(
+  options: {
+    viewerId: string;
+    adventureId: string;
+  },
+  client?: PoolClient
+): Promise<(AdventureCard & { placeLabel: string | null; updatedAt: string }) | null> {
+  const visibleAdventure = await getVisibleAdventureById(options, client);
+  if (!visibleAdventure) {
+    return null;
+  }
+
+  await runQuery(
+    client,
+    `
+      delete from public.adventure_favorites
+      where user_id = $1::uuid
+        and adventure_id = $2::uuid
+    `,
+    [options.viewerId, options.adventureId]
+  );
+
+  return getVisibleAdventureById(options, client);
 }

--- a/src/features/adventures/routes.ts
+++ b/src/features/adventures/routes.ts
@@ -8,7 +8,9 @@ import { listOwnedMediaAssetsForAdventureCreate } from "../media/repository.js";
 import { checkMediaObjectExists } from "../media/storage.js";
 import {
   createAdventure,
+  deleteAdventureFavorite,
   getAdventureById,
+  insertAdventureFavorite,
   listAdventureMedia,
   listFeed
 } from "./repository.js";
@@ -173,6 +175,58 @@ export async function adventureRoutes(app: FastifyInstance): Promise<void> {
 
     return {
       items
+    };
+  });
+
+  app.post("/adventures/:id/favorite", async (request, reply) => {
+    const viewer = request.authContext?.viewer;
+    if (!viewer) {
+      return reply.code(403).send({
+        error: "Adventure favorites require a completed local account."
+      });
+    }
+
+    detailQuerySchema.parse(request.query);
+    const params = detailParamsSchema.parse(request.params);
+    const adventure = await insertAdventureFavorite({
+      viewerId: viewer.id,
+      adventureId: params.id
+    });
+
+    if (!adventure) {
+      return reply.code(404).send({
+        error: "Adventure not found."
+      });
+    }
+
+    return {
+      item: adventure
+    };
+  });
+
+  app.delete("/adventures/:id/favorite", async (request, reply) => {
+    const viewer = request.authContext?.viewer;
+    if (!viewer) {
+      return reply.code(403).send({
+        error: "Adventure favorites require a completed local account."
+      });
+    }
+
+    detailQuerySchema.parse(request.query);
+    const params = detailParamsSchema.parse(request.params);
+    const adventure = await deleteAdventureFavorite({
+      viewerId: viewer.id,
+      adventureId: params.id
+    });
+
+    if (!adventure) {
+      return reply.code(404).send({
+        error: "Adventure not found."
+      });
+    }
+
+    return {
+      item: adventure
     };
   });
 

--- a/src/features/discover/repository.ts
+++ b/src/features/discover/repository.ts
@@ -40,6 +40,7 @@ type DiscoverAdventureRow = QueryResultRow & {
   rating_count: number | null;
   average_rating: number | null;
   place_label: string | null;
+  is_favorited: boolean | null;
 };
 
 export type DiscoverAdventurer = {
@@ -149,7 +150,8 @@ function mapAdventureCard(row: DiscoverAdventureRow): AdventureCard {
       commentCount: row.comment_count ?? 0,
       ratingCount: row.rating_count ?? 0,
       averageRating: row.average_rating ?? 0
-    }
+    },
+    isFavorited: row.is_favorited ?? false
   };
 }
 
@@ -174,7 +176,14 @@ const discoverAdventureSelect = `
     adventure_stats.comment_count,
     adventure_stats.rating_count,
     adventure_stats.average_rating,
-    adventures.place_label
+    adventures.place_label,
+    exists (
+      select 1
+      from viewer
+      join public.adventure_favorites
+        on public.adventure_favorites.user_id = viewer.id
+      where public.adventure_favorites.adventure_id = adventures.id
+    ) as is_favorited
   from public.adventures adventures
   join public.users users
     on users.id = adventures.author_user_id
@@ -213,7 +222,7 @@ const discoverTopCategoriesLateral = `
   ) top_categories on true
 `;
 
-export async function listDiscoverHome(): Promise<DiscoverHomeResponse> {
+export async function listDiscoverHome(viewerId: string): Promise<DiscoverHomeResponse> {
   const adventurersResult = await db.query<DiscoverAdventurerRow>(
     `
       with ranked_adventurers as (
@@ -291,6 +300,9 @@ export async function listDiscoverHome(): Promise<DiscoverHomeResponse> {
 
   const adventuresResult = await db.query<DiscoverAdventureRow>(
     `
+      with viewer as (
+        select $1::uuid as id
+      )
       ${discoverAdventureSelect}
       where adventures.status = 'published'
         and adventures.visibility = 'public'
@@ -301,7 +313,8 @@ export async function listDiscoverHome(): Promise<DiscoverHomeResponse> {
         adventures.published_at desc nulls last,
         adventures.id desc
       limit 10
-    `
+    `,
+    [viewerId]
   );
 
   return {
@@ -323,6 +336,7 @@ export async function listDiscoverHome(): Promise<DiscoverHomeResponse> {
 }
 
 export async function searchDiscover(options: {
+  viewerId: string;
   query: string;
   limit: number;
   offset: number;
@@ -418,6 +432,9 @@ export async function searchDiscover(options: {
 
   const adventuresResult = await db.query<DiscoverAdventureRow>(
     `
+      with viewer as (
+        select $6::uuid as id
+      )
       ${discoverAdventureSelect}
       where adventures.status = 'published'
         and adventures.visibility = 'public'
@@ -438,7 +455,7 @@ export async function searchDiscover(options: {
       limit $1
       offset $2
     `,
-    [options.limit, options.offset, needle, options.query, prefix]
+    [options.limit, options.offset, needle, options.query, prefix, options.viewerId]
   );
 
   return {

--- a/src/features/discover/routes.ts
+++ b/src/features/discover/routes.ts
@@ -39,7 +39,7 @@ export async function discoverRoutes(app: FastifyInstance): Promise<void> {
       return reply;
     }
 
-    return listDiscoverHome();
+    return listDiscoverHome(viewer.id);
   });
 
   app.get("/discover/search", async (request, reply) => {
@@ -50,6 +50,7 @@ export async function discoverRoutes(app: FastifyInstance): Promise<void> {
 
     const query = searchQuerySchema.parse(request.query);
     const result = await searchDiscover({
+      viewerId: viewer.id,
       query: query.q,
       limit: query.limit,
       offset: query.offset

--- a/src/features/profiles/repository.ts
+++ b/src/features/profiles/repository.ts
@@ -31,12 +31,18 @@ type ProfileAdventureRow = QueryResultRow & {
   published_at: string | null;
   latitude: number | null;
   longitude: number | null;
+  author_handle: string;
+  author_display_name: string | null;
+  author_home_city: string | null;
+  author_home_region: string | null;
   primary_media_id: string | null;
   primary_media_storage_key: string | null;
   favorite_count: number | null;
   comment_count: number | null;
   rating_count: number | null;
   average_rating: number | null;
+  place_label: string | null;
+  is_favorited: boolean | null;
 };
 
 export type ProfileDetail = {
@@ -117,7 +123,12 @@ function mapProfile(row: ProfileRow): ProfileDetail {
   };
 }
 
-function mapProfileAdventure(row: ProfileAdventureRow, author: ProfileDetail): AdventureCard {
+function mapProfileAdventure(
+  row: ProfileAdventureRow,
+  options?: {
+    includePlaceLabel?: boolean;
+  }
+): AdventureCard {
   return {
     id: row.id,
     title: row.title,
@@ -133,12 +144,12 @@ function mapProfileAdventure(row: ProfileAdventureRow, author: ProfileDetail): A
             longitude: row.longitude
           }
         : null,
-    placeLabel: null,
+    placeLabel: options?.includePlaceLabel ? row.place_label : null,
     author: {
-      handle: author.handle,
-      displayName: author.displayName,
-      homeCity: author.homeCity,
-      homeRegion: author.homeRegion
+      handle: row.author_handle,
+      displayName: row.author_display_name,
+      homeCity: row.author_home_city,
+      homeRegion: row.author_home_region
     },
     primaryMedia:
       row.primary_media_id && row.primary_media_storage_key
@@ -152,7 +163,8 @@ function mapProfileAdventure(row: ProfileAdventureRow, author: ProfileDetail): A
       commentCount: row.comment_count ?? 0,
       ratingCount: row.rating_count ?? 0,
       averageRating: row.average_rating ?? 0
-    }
+    },
+    isFavorited: row.is_favorited ?? false
   };
 }
 
@@ -327,12 +339,23 @@ export async function listProfileAdventures(options: {
         adventures.published_at::text as published_at,
         st_y(adventures.location::geometry) as latitude,
         st_x(adventures.location::geometry) as longitude,
+        author.handle as author_handle,
+        profile_record.display_name as author_display_name,
+        profile_record.home_city as author_home_city,
+        profile_record.home_region as author_home_region,
         media_assets.id::text as primary_media_id,
         media_assets.storage_key as primary_media_storage_key,
         adventure_stats.favorite_count,
         adventure_stats.comment_count,
         adventure_stats.rating_count,
-        adventure_stats.average_rating
+        adventure_stats.average_rating,
+        adventures.place_label,
+        exists (
+          select 1
+          from public.adventure_favorites
+          where public.adventure_favorites.user_id = $1::uuid
+            and public.adventure_favorites.adventure_id = adventures.id
+        ) as is_favorited
       from public.adventures adventures
       left join public.adventure_media adventure_media
         on adventure_media.adventure_id = adventures.id
@@ -343,6 +366,8 @@ export async function listProfileAdventures(options: {
         on adventure_stats.adventure_id = adventures.id
       join public.users author
         on author.id = adventures.author_user_id
+      left join public.profiles profile_record
+        on profile_record.user_id = author.id
       where author.handle = $2
         and adventures.status = 'published'
         and ${profileAdventureVisibilityClause()}
@@ -353,5 +378,75 @@ export async function listProfileAdventures(options: {
     [options.viewerId ?? null, options.profileHandle, options.limit, options.offset]
   );
 
-  return result.rows.map((row) => mapProfileAdventure(row, profile));
+  return result.rows.map((row) => mapProfileAdventure(row));
+}
+
+export async function listProfileFavorites(options: {
+  profileHandle: string;
+  viewerId: string;
+  limit: number;
+  offset: number;
+}): Promise<AdventureCard[]> {
+  const profile = await getProfileByHandle(options.profileHandle);
+  if (!profile) {
+    return [];
+  }
+
+  const result = await db.query<ProfileAdventureRow>(
+    `
+      with viewer as (
+        select $1::uuid as id
+      )
+      select
+        adventures.id::text as id,
+        adventures.title,
+        adventures.description,
+        adventures.category_slug,
+        adventures.visibility::text as visibility,
+        adventures.created_at::text as created_at,
+        adventures.published_at::text as published_at,
+        st_y(adventures.location::geometry) as latitude,
+        st_x(adventures.location::geometry) as longitude,
+        users.handle as author_handle,
+        profiles.display_name as author_display_name,
+        profiles.home_city as author_home_city,
+        profiles.home_region as author_home_region,
+        media_assets.id::text as primary_media_id,
+        media_assets.storage_key as primary_media_storage_key,
+        adventure_stats.favorite_count,
+        adventure_stats.comment_count,
+        adventure_stats.rating_count,
+        adventure_stats.average_rating,
+        adventures.place_label,
+        exists (
+          select 1
+          from public.adventure_favorites
+          where public.adventure_favorites.user_id = $1::uuid
+            and public.adventure_favorites.adventure_id = adventures.id
+        ) as is_favorited
+      from public.adventure_favorites
+      join public.adventures adventures
+        on adventures.id = public.adventure_favorites.adventure_id
+      join public.users users
+        on users.id = adventures.author_user_id
+      left join public.profiles profiles
+        on profiles.user_id = users.id
+      left join public.adventure_media adventure_media
+        on adventure_media.adventure_id = adventures.id
+       and adventure_media.is_primary = true
+      left join public.media_assets media_assets
+        on media_assets.id = adventure_media.media_asset_id
+      left join public.adventure_stats adventure_stats
+        on adventure_stats.adventure_id = adventures.id
+      where public.adventure_favorites.user_id = $1::uuid
+        and adventures.status = 'published'
+        and ${profileAdventureVisibilityClause()}
+      order by public.adventure_favorites.created_at desc, adventures.id desc
+      limit $2
+      offset $3
+    `,
+    [options.viewerId, options.limit, options.offset]
+  );
+
+  return result.rows.map((row) => mapProfileAdventure(row, { includePlaceLabel: true }));
 }

--- a/src/features/profiles/routes.ts
+++ b/src/features/profiles/routes.ts
@@ -6,6 +6,7 @@ import {
   getProfileByHandle,
   getProfileByUserId,
   listProfileAdventures,
+  listProfileFavorites,
   updateMyProfile,
   type MeProfileUpdateRequest
 } from "./repository.js";
@@ -66,6 +67,38 @@ export async function profileRoutes(app: FastifyInstance): Promise<void> {
         limit: query.limit,
         offset: query.offset,
         returned: adventures.length
+      }
+    };
+  });
+
+  app.get("/profiles/:handle/favorites", async (request, reply) => {
+    const viewer = requireViewer(request, reply);
+    if (!viewer) {
+      return reply;
+    }
+
+    const params = profileParamsSchema.parse(request.params);
+    const query = profileQuerySchema.parse(request.query);
+
+    if (params.handle !== viewer.handle) {
+      return reply.code(403).send({
+        error: "Forbidden."
+      });
+    }
+
+    const items = await listProfileFavorites({
+      profileHandle: params.handle,
+      viewerId: viewer.id,
+      limit: query.limit,
+      offset: query.offset
+    });
+
+    return {
+      items,
+      paging: {
+        limit: query.limit,
+        offset: query.offset,
+        returned: items.length
       }
     };
   });

--- a/tests/adventures.repository.test.ts
+++ b/tests/adventures.repository.test.ts
@@ -12,7 +12,9 @@ vi.mock("../src/db/client.js", () => ({
 
 import {
   createAdventure,
+  deleteAdventureFavorite,
   getAdventureById,
+  insertAdventureFavorite,
   listAdventureMedia,
   listFeed
 } from "../src/features/adventures/repository.js";
@@ -46,7 +48,8 @@ describe("adventures repository", () => {
           rating_count: null,
           average_rating: null,
           place_label: null,
-          distance_miles: null
+          distance_miles: null,
+          is_favorited: true
         }
       ]
     });
@@ -81,7 +84,8 @@ describe("adventures repository", () => {
             commentCount: 0,
             ratingCount: 0,
             averageRating: 0
-          }
+          },
+          isFavorited: true
         }
       ]
     });
@@ -124,7 +128,8 @@ describe("adventures repository", () => {
           rating_count: null,
           average_rating: null,
           place_label: null,
-          distance_miles: null
+          distance_miles: null,
+          is_favorited: false
         }
       ]
     });
@@ -162,7 +167,8 @@ describe("adventures repository", () => {
           rating_count: null,
           average_rating: null,
           place_label: "Topanga",
-          distance_miles: 7.4
+          distance_miles: 7.4,
+          is_favorited: true
         }
       ]
     });
@@ -188,7 +194,8 @@ describe("adventures repository", () => {
       items: [
         expect.objectContaining({
           id: "adventure-1",
-          distanceMiles: 7.4
+          distanceMiles: 7.4,
+          isFavorited: true
         })
       ]
     });
@@ -235,6 +242,48 @@ describe("adventures repository", () => {
     );
     expect(dbMock.query.mock.calls[0]?.[0]).not.toContain("scope.center_point");
     expect(dbMock.query.mock.calls[0]?.[0]).not.toContain("cross join scope");
+  });
+
+  it("maps isFavorited on visible detail lookups", async () => {
+    dbMock.query.mockResolvedValue({
+      rows: [
+        {
+          id: "adventure-1",
+          title: "Quiet Ridge",
+          description: null,
+          category_slug: "viewpoints",
+          visibility: "public",
+          created_at: "2026-03-01T00:00:00.000Z",
+          published_at: null,
+          latitude: null,
+          longitude: null,
+          author_handle: "jacksanfil",
+          author_display_name: null,
+          author_home_city: null,
+          author_home_region: null,
+          primary_media_id: null,
+          primary_media_storage_key: null,
+          favorite_count: null,
+          comment_count: null,
+          rating_count: null,
+          average_rating: null,
+          place_label: "Topanga",
+          updated_at: "2026-03-03T00:00:00.000Z",
+          is_favorited: true
+        }
+      ]
+    });
+
+    const result = await getAdventureById({
+      adventureId: "4b5edc1d-f292-45b4-8972-7b977ebf5298",
+      viewerId: "viewer-123"
+    });
+
+    expect(result).toEqual(expect.objectContaining({
+      id: "adventure-1",
+      isFavorited: true,
+      updatedAt: "2026-03-03T00:00:00.000Z"
+    }));
   });
 
   it("returns ordered adventure media for a visible detail carousel", async () => {
@@ -368,6 +417,158 @@ describe("adventures repository", () => {
       3,
       expect.stringContaining("insert into public.adventure_media"),
       [expect.any(String), "media-2", 1, false]
+    );
+  });
+
+  it("inserts a favorite idempotently and returns the hydrated adventure", async () => {
+    dbMock.query
+      .mockResolvedValueOnce({
+        rows: [
+          {
+            id: "adventure-1",
+            title: "Quiet Ridge",
+            description: null,
+            category_slug: "viewpoints",
+            visibility: "public",
+            created_at: "2026-03-01T00:00:00.000Z",
+            published_at: null,
+            latitude: null,
+            longitude: null,
+            author_handle: "jacksanfil",
+            author_display_name: null,
+            author_home_city: null,
+            author_home_region: null,
+            primary_media_id: null,
+            primary_media_storage_key: null,
+            favorite_count: 1,
+            comment_count: 0,
+            rating_count: 0,
+            average_rating: 0,
+            place_label: null,
+            updated_at: "2026-03-03T00:00:00.000Z",
+            is_favorited: false
+          }
+        ]
+      })
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({
+        rows: [
+          {
+            id: "adventure-1",
+            title: "Quiet Ridge",
+            description: null,
+            category_slug: "viewpoints",
+            visibility: "public",
+            created_at: "2026-03-01T00:00:00.000Z",
+            published_at: null,
+            latitude: null,
+            longitude: null,
+            author_handle: "jacksanfil",
+            author_display_name: null,
+            author_home_city: null,
+            author_home_region: null,
+            primary_media_id: null,
+            primary_media_storage_key: null,
+            favorite_count: 1,
+            comment_count: 0,
+            rating_count: 0,
+            average_rating: 0,
+            place_label: null,
+            updated_at: "2026-03-03T00:00:00.000Z",
+            is_favorited: true
+          }
+        ]
+      });
+
+    const result = await insertAdventureFavorite({
+      viewerId: "viewer-123",
+      adventureId: "4b5edc1d-f292-45b4-8972-7b977ebf5298"
+    });
+
+    expect(result).toEqual(expect.objectContaining({
+      id: "adventure-1",
+      isFavorited: true
+    }));
+    expect(dbMock.query).toHaveBeenNthCalledWith(
+      2,
+      expect.stringContaining("on conflict (user_id, adventure_id) do nothing"),
+      ["viewer-123", "4b5edc1d-f292-45b4-8972-7b977ebf5298"]
+    );
+  });
+
+  it("deletes a favorite idempotently and returns the hydrated adventure", async () => {
+    dbMock.query
+      .mockResolvedValueOnce({
+        rows: [
+          {
+            id: "adventure-1",
+            title: "Quiet Ridge",
+            description: null,
+            category_slug: "viewpoints",
+            visibility: "public",
+            created_at: "2026-03-01T00:00:00.000Z",
+            published_at: null,
+            latitude: null,
+            longitude: null,
+            author_handle: "jacksanfil",
+            author_display_name: null,
+            author_home_city: null,
+            author_home_region: null,
+            primary_media_id: null,
+            primary_media_storage_key: null,
+            favorite_count: 1,
+            comment_count: 0,
+            rating_count: 0,
+            average_rating: 0,
+            place_label: null,
+            updated_at: "2026-03-03T00:00:00.000Z",
+            is_favorited: true
+          }
+        ]
+      })
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({
+        rows: [
+          {
+            id: "adventure-1",
+            title: "Quiet Ridge",
+            description: null,
+            category_slug: "viewpoints",
+            visibility: "public",
+            created_at: "2026-03-01T00:00:00.000Z",
+            published_at: null,
+            latitude: null,
+            longitude: null,
+            author_handle: "jacksanfil",
+            author_display_name: null,
+            author_home_city: null,
+            author_home_region: null,
+            primary_media_id: null,
+            primary_media_storage_key: null,
+            favorite_count: 0,
+            comment_count: 0,
+            rating_count: 0,
+            average_rating: 0,
+            place_label: null,
+            updated_at: "2026-03-03T00:00:00.000Z",
+            is_favorited: false
+          }
+        ]
+      });
+
+    const result = await deleteAdventureFavorite({
+      viewerId: "viewer-123",
+      adventureId: "4b5edc1d-f292-45b4-8972-7b977ebf5298"
+    });
+
+    expect(result).toEqual(expect.objectContaining({
+      id: "adventure-1",
+      isFavorited: false
+    }));
+    expect(dbMock.query).toHaveBeenNthCalledWith(
+      2,
+      expect.stringContaining("delete from public.adventure_favorites"),
+      ["viewer-123", "4b5edc1d-f292-45b4-8972-7b977ebf5298"]
     );
   });
 });

--- a/tests/adventures.routes.test.ts
+++ b/tests/adventures.routes.test.ts
@@ -8,7 +8,9 @@ const {
   dbMock,
   checkMediaObjectExistsMock,
   createAdventureMock,
+  deleteAdventureFavoriteMock,
   getAdventureByIdMock,
+  insertAdventureFavoriteMock,
   listAdventureMediaMock,
   listFeedMock
 } = vi.hoisted(() => ({
@@ -17,7 +19,9 @@ const {
   },
   checkMediaObjectExistsMock: vi.fn(),
   createAdventureMock: vi.fn(),
+  deleteAdventureFavoriteMock: vi.fn(),
   getAdventureByIdMock: vi.fn(),
+  insertAdventureFavoriteMock: vi.fn(),
   listAdventureMediaMock: vi.fn(),
   listFeedMock: vi.fn()
 }));
@@ -32,7 +36,9 @@ const { listOwnedMediaAssetsForAdventureCreateMock } = vi.hoisted(() => ({
 
 vi.mock("../src/features/adventures/repository.js", () => ({
   createAdventure: createAdventureMock,
+  deleteAdventureFavorite: deleteAdventureFavoriteMock,
   getAdventureById: getAdventureByIdMock,
+  insertAdventureFavorite: insertAdventureFavoriteMock,
   listAdventureMedia: listAdventureMediaMock,
   listFeed: listFeedMock
 }));
@@ -71,7 +77,8 @@ async function buildAdventureRouteApp(viewerId?: string) {
       ? {
           identity: localIdentityFixtures.connected_viewer.identity,
           viewer: {
-            id: viewerId
+            id: viewerId,
+            handle: localIdentityFixtures.connected_viewer.seededUser?.handle
           }
         }
       : null;
@@ -89,6 +96,8 @@ describe("adventure routes", () => {
     );
     listFeedMock.mockReset();
     createAdventureMock.mockReset();
+    insertAdventureFavoriteMock.mockReset();
+    deleteAdventureFavoriteMock.mockReset();
     getAdventureByIdMock.mockReset();
     listAdventureMediaMock.mockReset();
     listOwnedMediaAssetsForAdventureCreateMock.mockReset();
@@ -349,6 +358,191 @@ describe("adventure routes", () => {
       error: "Authentication required."
     });
     expect(getAdventureByIdMock).not.toHaveBeenCalled();
+
+    await app.close();
+  });
+
+  it("favorites an adventure and returns the hydrated item", async () => {
+    insertAdventureFavoriteMock.mockResolvedValue({
+      id: "adventure-1",
+      title: "Hidden Falls",
+      description: "Bring water and wear good shoes.",
+      categorySlug: "water_spots",
+      visibility: "public",
+      createdAt: "2026-03-01T00:00:00.000Z",
+      publishedAt: "2026-03-02T00:00:00.000Z",
+      updatedAt: "2026-03-03T00:00:00.000Z",
+      placeLabel: "Hidden Falls Trailhead",
+      location: null,
+      author: {
+        handle: "jacksanfil",
+        displayName: "Jack",
+        homeCity: "Los Angeles",
+        homeRegion: "CA"
+      },
+      primaryMedia: null,
+      stats: {
+        favoriteCount: 1,
+        commentCount: 0,
+        ratingCount: 0,
+        averageRating: 0
+      },
+      isFavorited: true
+    });
+
+    const app = await buildAdventureRouteApp(localIdentityFixtures.connected_viewer.seededUser?.id);
+    const response = await app.inject({
+      method: "POST",
+      url: "/api/adventures/3bb3ba5f-06ae-4f5e-a6ce-45cb62cc87ab/favorite"
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(insertAdventureFavoriteMock).toHaveBeenCalledWith({
+      viewerId: localIdentityFixtures.connected_viewer.seededUser?.id,
+      adventureId: "3bb3ba5f-06ae-4f5e-a6ce-45cb62cc87ab"
+    });
+    expect(response.json()).toEqual({
+      item: expect.objectContaining({
+        id: "adventure-1",
+        isFavorited: true
+      })
+    });
+
+    await app.close();
+  });
+
+  it("treats duplicate favorite posts as idempotent", async () => {
+    insertAdventureFavoriteMock.mockResolvedValue({
+      id: "adventure-1",
+      title: "Hidden Falls",
+      description: "Bring water and wear good shoes.",
+      categorySlug: "water_spots",
+      visibility: "public",
+      createdAt: "2026-03-01T00:00:00.000Z",
+      publishedAt: "2026-03-02T00:00:00.000Z",
+      updatedAt: "2026-03-03T00:00:00.000Z",
+      placeLabel: "Hidden Falls Trailhead",
+      location: null,
+      author: {
+        handle: "jacksanfil",
+        displayName: "Jack",
+        homeCity: "Los Angeles",
+        homeRegion: "CA"
+      },
+      primaryMedia: null,
+      stats: {
+        favoriteCount: 1,
+        commentCount: 0,
+        ratingCount: 0,
+        averageRating: 0
+      },
+      isFavorited: true
+    });
+
+    const app = await buildAdventureRouteApp(localIdentityFixtures.connected_viewer.seededUser?.id);
+    const response = await app.inject({
+      method: "POST",
+      url: "/api/adventures/3bb3ba5f-06ae-4f5e-a6ce-45cb62cc87ab/favorite"
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json()).toEqual({
+      item: expect.objectContaining({
+        isFavorited: true
+      })
+    });
+
+    await app.close();
+  });
+
+  it("unfavorites an adventure and returns the hydrated item", async () => {
+    deleteAdventureFavoriteMock.mockResolvedValue({
+      id: "adventure-1",
+      title: "Hidden Falls",
+      description: "Bring water and wear good shoes.",
+      categorySlug: "water_spots",
+      visibility: "public",
+      createdAt: "2026-03-01T00:00:00.000Z",
+      publishedAt: "2026-03-02T00:00:00.000Z",
+      updatedAt: "2026-03-03T00:00:00.000Z",
+      placeLabel: "Hidden Falls Trailhead",
+      location: null,
+      author: {
+        handle: "jacksanfil",
+        displayName: "Jack",
+        homeCity: "Los Angeles",
+        homeRegion: "CA"
+      },
+      primaryMedia: null,
+      stats: {
+        favoriteCount: 0,
+        commentCount: 0,
+        ratingCount: 0,
+        averageRating: 0
+      },
+      isFavorited: false
+    });
+
+    const app = await buildAdventureRouteApp(localIdentityFixtures.connected_viewer.seededUser?.id);
+    const response = await app.inject({
+      method: "DELETE",
+      url: "/api/adventures/3bb3ba5f-06ae-4f5e-a6ce-45cb62cc87ab/favorite"
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(deleteAdventureFavoriteMock).toHaveBeenCalledWith({
+      viewerId: localIdentityFixtures.connected_viewer.seededUser?.id,
+      adventureId: "3bb3ba5f-06ae-4f5e-a6ce-45cb62cc87ab"
+    });
+    expect(response.json()).toEqual({
+      item: expect.objectContaining({
+        isFavorited: false
+      })
+    });
+
+    await app.close();
+  });
+
+  it("treats missing favorite deletes as idempotent", async () => {
+    deleteAdventureFavoriteMock.mockResolvedValue({
+      id: "adventure-1",
+      title: "Hidden Falls",
+      description: "Bring water and wear good shoes.",
+      categorySlug: "water_spots",
+      visibility: "public",
+      createdAt: "2026-03-01T00:00:00.000Z",
+      publishedAt: "2026-03-02T00:00:00.000Z",
+      updatedAt: "2026-03-03T00:00:00.000Z",
+      placeLabel: "Hidden Falls Trailhead",
+      location: null,
+      author: {
+        handle: "jacksanfil",
+        displayName: "Jack",
+        homeCity: "Los Angeles",
+        homeRegion: "CA"
+      },
+      primaryMedia: null,
+      stats: {
+        favoriteCount: 0,
+        commentCount: 0,
+        ratingCount: 0,
+        averageRating: 0
+      },
+      isFavorited: false
+    });
+
+    const app = await buildAdventureRouteApp(localIdentityFixtures.connected_viewer.seededUser?.id);
+    const response = await app.inject({
+      method: "DELETE",
+      url: "/api/adventures/3bb3ba5f-06ae-4f5e-a6ce-45cb62cc87ab/favorite"
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json()).toEqual({
+      item: expect.objectContaining({
+        isFavorited: false
+      })
+    });
 
     await app.close();
   });

--- a/tests/app.test.ts
+++ b/tests/app.test.ts
@@ -85,6 +85,7 @@ function makeAdventureRow(overrides: Record<string, unknown> = {}) {
     rating_count: 2,
     average_rating: 4.5,
     place_label: "Hidden Falls Trailhead",
+    is_favorited: false,
     distance_miles: null,
     updated_at: "2026-03-03T00:00:00.000Z",
     ...overrides
@@ -240,7 +241,8 @@ describe("buildApp", () => {
             commentCount: 3,
             ratingCount: 2,
             averageRating: 4.5
-          }
+          },
+          isFavorited: false
         }
       ],
       paging: {
@@ -310,6 +312,7 @@ describe("buildApp", () => {
             ratingCount: 2,
             averageRating: 4.5
           },
+          isFavorited: false,
           distanceMiles: 7.4
         }
       ],
@@ -430,7 +433,8 @@ describe("buildApp", () => {
                 commentCount: 118,
                 ratingCount: 847,
                 averageRating: 4.9
-              }
+              },
+              isFavorited: false
             }
           ]
         }
@@ -535,7 +539,8 @@ describe("buildApp", () => {
               commentCount: 3,
               ratingCount: 2,
               averageRating: 4.5
-            }
+            },
+            isFavorited: false
           }
         ],
         paging: {
@@ -709,7 +714,8 @@ describe("buildApp", () => {
           commentCount: 3,
           ratingCount: 2,
           averageRating: 4.5
-        }
+        },
+        isFavorited: false
       }
     });
     await app.close();
@@ -878,7 +884,7 @@ describe("buildApp", () => {
         rows: [makeProfileRow()]
       } as QueryRows<Record<string, unknown>>)
       .mockResolvedValueOnce({
-        rows: [makeAdventureRow({ author_handle: undefined, author_display_name: undefined })]
+        rows: [makeAdventureRow()]
       } as QueryRows<Record<string, unknown>>);
 
     const app = await buildApp();
@@ -938,7 +944,8 @@ describe("buildApp", () => {
             commentCount: 3,
             ratingCount: 2,
             averageRating: 4.5
-          }
+          },
+          isFavorited: false
         }
       ],
       paging: {
@@ -947,6 +954,116 @@ describe("buildApp", () => {
         returned: 1
       }
     });
+    await app.close();
+  });
+
+  it("favorites an adventure through the registered app routes", async () => {
+    dbMock.query
+      .mockResolvedValueOnce({
+        rows: [makeLocalUserRow()]
+      } as QueryRows<Record<string, unknown>>)
+      .mockResolvedValueOnce({
+        rows: [makeAdventureRow({ is_favorited: false })]
+      } as QueryRows<Record<string, unknown>>)
+      .mockResolvedValueOnce({
+        rows: []
+      } as QueryRows<Record<string, unknown>>)
+      .mockResolvedValueOnce({
+        rows: [makeAdventureRow({ is_favorited: true })]
+      } as QueryRows<Record<string, unknown>>);
+
+    const app = await buildApp();
+
+    const response = await app.inject({
+      method: "POST",
+      url: "/api/adventures/3bb3ba5f-06ae-4f5e-a6ce-45cb62cc87ab/favorite",
+      headers: authHeaders()
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json()).toEqual({
+      item: expect.objectContaining({
+        id: "adventure-1",
+        isFavorited: true
+      })
+    });
+
+    await app.close();
+  });
+
+  it("unfavorites an adventure through the registered app routes", async () => {
+    dbMock.query
+      .mockResolvedValueOnce({
+        rows: [makeLocalUserRow()]
+      } as QueryRows<Record<string, unknown>>)
+      .mockResolvedValueOnce({
+        rows: [makeAdventureRow({ is_favorited: true })]
+      } as QueryRows<Record<string, unknown>>)
+      .mockResolvedValueOnce({
+        rows: []
+      } as QueryRows<Record<string, unknown>>)
+      .mockResolvedValueOnce({
+        rows: [makeAdventureRow({ is_favorited: false })]
+      } as QueryRows<Record<string, unknown>>);
+
+    const app = await buildApp();
+
+    const response = await app.inject({
+      method: "DELETE",
+      url: "/api/adventures/3bb3ba5f-06ae-4f5e-a6ce-45cb62cc87ab/favorite",
+      headers: authHeaders()
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json()).toEqual({
+      item: expect.objectContaining({
+        id: "adventure-1",
+        isFavorited: false
+      })
+    });
+
+    await app.close();
+  });
+
+  it("returns the authenticated viewer favorites collection", async () => {
+    dbMock.query
+      .mockResolvedValueOnce({
+        rows: [makeLocalUserRow()]
+      } as QueryRows<Record<string, unknown>>)
+      .mockResolvedValueOnce({
+        rows: [makeProfileRow({
+          handle: localIdentityFixtures.connected_viewer.seededUser?.handle,
+          display_name: "Viewer"
+        })]
+      } as QueryRows<Record<string, unknown>>)
+      .mockResolvedValueOnce({
+        rows: [makeAdventureRow({ is_favorited: true, place_label: "Malibu" })]
+      } as QueryRows<Record<string, unknown>>);
+
+    const app = await buildApp();
+
+    const response = await app.inject({
+      method: "GET",
+      url: `/api/profiles/${localIdentityFixtures.connected_viewer.seededUser?.handle}/favorites?limit=1&offset=0`,
+      headers: authHeaders()
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json()).toEqual({
+      items: [
+        expect.objectContaining({
+          id: "adventure-1",
+          placeLabel: "Malibu",
+          isFavorited: true
+        })
+      ],
+      paging: {
+        limit: 1,
+        offset: 0,
+        returned: 1
+      }
+    });
+
     await app.close();
   });
 

--- a/tests/discover.repository.test.ts
+++ b/tests/discover.repository.test.ts
@@ -62,12 +62,13 @@ describe("discover repository", () => {
             rating_count: 847,
             average_rating: 4.9,
             place_label: "Columbia River Gorge, OR",
-            distance_miles: null
+            distance_miles: null,
+            is_favorited: true
           }
         ]
       });
 
-    const result = await listDiscoverHome();
+    const result = await listDiscoverHome("viewer-1");
 
     expect(result).toEqual({
       modules: [
@@ -128,7 +129,8 @@ describe("discover repository", () => {
                 commentCount: 118,
                 ratingCount: 847,
                 averageRating: 4.9
-              }
+              },
+              isFavorited: true
             }
           ]
         }
@@ -148,7 +150,7 @@ describe("discover repository", () => {
         rows: []
       });
 
-    await listDiscoverHome();
+    await listDiscoverHome("viewer-1");
 
     expect(dbMock.query.mock.calls[0]?.[0]).toContain("array_agg(top_categories.category_slug order by");
     expect(dbMock.query.mock.calls[0]?.[0]).toContain("group by category_slug");
@@ -197,12 +199,14 @@ describe("discover repository", () => {
             rating_count: 847,
             average_rating: 4.9,
             place_label: "Columbia River Gorge, OR",
-            distance_miles: null
+            distance_miles: null,
+            is_favorited: false
           }
         ]
       });
 
     const result = await searchDiscover({
+      viewerId: "viewer-1",
       query: "Maya",
       limit: 5,
       offset: 10
@@ -222,13 +226,14 @@ describe("discover repository", () => {
         items: [
           expect.objectContaining({
             id: "adventure-1",
-            title: "Eagle Creek Trail to Tunnel Falls"
+            title: "Eagle Creek Trail to Tunnel Falls",
+            isFavorited: false
           })
         ]
       }
     });
     expect(dbMock.query.mock.calls[0]?.[1]).toEqual([5, 10, "%Maya%", "Maya", "Maya%"]);
-    expect(dbMock.query.mock.calls[1]?.[1]).toEqual([5, 10, "%Maya%", "Maya", "Maya%"]);
+    expect(dbMock.query.mock.calls[1]?.[1]).toEqual([5, 10, "%Maya%", "Maya", "Maya%", "viewer-1"]);
     expect(dbMock.query.mock.calls[0]?.[0]).toContain("users.handle ilike $3");
     expect(dbMock.query.mock.calls[1]?.[0]).toContain("adventures.place_label");
   });
@@ -243,6 +248,7 @@ describe("discover repository", () => {
       });
 
     await searchDiscover({
+      viewerId: "viewer-1",
       query: "Maya",
       limit: 5,
       offset: 0

--- a/tests/discover.routes.test.ts
+++ b/tests/discover.routes.test.ts
@@ -98,7 +98,9 @@ describe("discover routes", () => {
     });
 
     expect(response.statusCode).toBe(200);
-    expect(listDiscoverHomeMock).toHaveBeenCalledWith();
+    expect(listDiscoverHomeMock).toHaveBeenCalledWith(
+      localIdentityFixtures.connected_viewer.seededUser?.id
+    );
     expect(response.json()).toEqual({
       modules: [
         {
@@ -138,6 +140,7 @@ describe("discover routes", () => {
 
     expect(response.statusCode).toBe(200);
     expect(searchDiscoverMock).toHaveBeenCalledWith({
+      viewerId: localIdentityFixtures.connected_viewer.seededUser?.id,
       query: "Maya",
       limit: 5,
       offset: 10

--- a/tests/profiles.repository.test.ts
+++ b/tests/profiles.repository.test.ts
@@ -14,6 +14,7 @@ import {
   getProfileByHandle,
   getProfileByUserId,
   listProfileAdventures,
+  listProfileFavorites,
   updateMyProfile
 } from "../src/features/profiles/repository.js";
 
@@ -199,12 +200,18 @@ describe("profiles repository", () => {
             published_at: "2026-03-02T00:00:00.000Z",
             latitude: 34.12,
             longitude: -118.45,
+            author_handle: "jacksanfil",
+            author_display_name: "Jack",
+            author_home_city: "Los Angeles",
+            author_home_region: "CA",
             primary_media_id: null,
             primary_media_storage_key: null,
             favorite_count: 1,
             comment_count: 2,
             rating_count: 3,
-            average_rating: 4.67
+            average_rating: 4.67,
+            place_label: "Malibu",
+            is_favorited: true
           }
         ]
       });
@@ -242,7 +249,8 @@ describe("profiles repository", () => {
           commentCount: 2,
           ratingCount: 3,
           averageRating: 4.67
-        }
+        },
+        isFavorited: true
       }
     ]);
     expect(dbMock.query).toHaveBeenNthCalledWith(2, expect.stringContaining("select $1::uuid as id"), [
@@ -285,12 +293,18 @@ describe("profiles repository", () => {
             published_at: "2026-03-02T00:00:00.000Z",
             latitude: 34.12,
             longitude: -118.45,
+            author_handle: "jacksanfil",
+            author_display_name: "Jack",
+            author_home_city: "Los Angeles",
+            author_home_region: "CA",
             primary_media_id: null,
             primary_media_storage_key: null,
             favorite_count: 1,
             comment_count: 2,
             rating_count: 3,
-            average_rating: 4.67
+            average_rating: 4.67,
+            place_label: null,
+            is_favorited: false
           }
         ]
       });
@@ -303,5 +317,78 @@ describe("profiles repository", () => {
     });
 
     expect(result[0]?.visibility).toBe("sidekicks");
+    expect(result[0]?.isFavorited).toBe(false);
+  });
+
+  it("lists a viewer favorites collection in save order", async () => {
+    dbMock.query
+      .mockResolvedValueOnce({
+        rows: [
+          {
+            user_id: "user-1",
+            handle: "viewer",
+            display_name: "Viewer",
+            bio: "Explorer",
+            home_city: "Portland",
+            home_region: "OR",
+            avatar_media_id: null,
+            avatar_storage_key: null,
+            cover_media_id: null,
+            cover_storage_key: null,
+            created_at: "2026-01-01T00:00:00.000Z",
+            updated_at: "2026-03-01T00:00:00.000Z"
+          }
+        ]
+      })
+      .mockResolvedValueOnce({
+        rows: [
+          {
+            id: "adventure-1",
+            title: "Quiet Ridge",
+            description: "Best at sunset.",
+            category_slug: "viewpoints",
+            visibility: "public",
+            created_at: "2026-03-01T00:00:00.000Z",
+            published_at: "2026-03-02T00:00:00.000Z",
+            latitude: 34.12,
+            longitude: -118.45,
+            author_handle: "viewer",
+            author_display_name: "Viewer",
+            author_home_city: "Portland",
+            author_home_region: "OR",
+            primary_media_id: null,
+            primary_media_storage_key: null,
+            favorite_count: 1,
+            comment_count: 2,
+            rating_count: 3,
+            average_rating: 4.67,
+            place_label: "Malibu",
+            is_favorited: true
+          }
+        ]
+      });
+
+    const result = await listProfileFavorites({
+      profileHandle: "viewer",
+      viewerId: "viewer-1",
+      limit: 10,
+      offset: 0
+    });
+
+    expect(result).toEqual([
+      expect.objectContaining({
+        id: "adventure-1",
+        placeLabel: "Malibu",
+        isFavorited: true
+      })
+    ]);
+    expect(dbMock.query).toHaveBeenNthCalledWith(
+      2,
+      expect.stringContaining("from public.adventure_favorites"),
+      ["viewer-1", 10, 0]
+    );
+    expect(dbMock.query.mock.calls[1]?.[0]).toContain(
+      "order by public.adventure_favorites.created_at desc, adventures.id desc"
+    );
   });
 });

--- a/tests/profiles.routes.test.ts
+++ b/tests/profiles.routes.test.ts
@@ -7,15 +7,24 @@ import {
   localIdentityFixtures
 } from "../src/features/auth/local-fixtures.js";
 
+vi.mock("../src/config/env.js", () => ({
+  env: {
+    AUTH_MODE: "local_identity",
+    SERVER_RUNTIME_MODE: "local_automation_test_core"
+  }
+}));
+
 const {
   getProfileByHandleMock,
   getProfileByUserIdMock,
   listProfileAdventuresMock,
+  listProfileFavoritesMock,
   updateMyProfileMock
 } = vi.hoisted(() => ({
   getProfileByHandleMock: vi.fn(),
   getProfileByUserIdMock: vi.fn(),
   listProfileAdventuresMock: vi.fn(),
+  listProfileFavoritesMock: vi.fn(),
   updateMyProfileMock: vi.fn()
 }));
 
@@ -23,6 +32,7 @@ vi.mock("../src/features/profiles/repository.js", () => ({
   getProfileByHandle: getProfileByHandleMock,
   getProfileByUserId: getProfileByUserIdMock,
   listProfileAdventures: listProfileAdventuresMock,
+  listProfileFavorites: listProfileFavoritesMock,
   updateMyProfile: updateMyProfileMock
 }));
 
@@ -45,7 +55,8 @@ async function buildProfileRouteApp(viewerId?: string) {
       ? {
           identity: localIdentityFixtures.connected_viewer.identity,
           viewer: {
-            id: viewerId
+            id: viewerId,
+            handle: localIdentityFixtures.connected_viewer.seededUser?.handle
           }
         }
       : null;
@@ -60,6 +71,7 @@ describe("profile routes", () => {
     getProfileByHandleMock.mockReset();
     getProfileByUserIdMock.mockReset();
     listProfileAdventuresMock.mockReset();
+    listProfileFavoritesMock.mockReset();
     updateMyProfileMock.mockReset();
   });
 
@@ -217,6 +229,83 @@ describe("profile routes", () => {
         handle: "viewer_handle"
       })
     });
+
+    await app.close();
+  });
+
+  it("returns the authenticated viewer favorites collection", async () => {
+    listProfileFavoritesMock.mockResolvedValue([
+      {
+        id: "adventure-1",
+        title: "Quiet Ridge",
+        description: "Best at sunset.",
+        categorySlug: "viewpoints",
+        visibility: "public",
+        createdAt: "2026-03-01T00:00:00.000Z",
+        publishedAt: "2026-03-02T00:00:00.000Z",
+        location: null,
+        placeLabel: "Malibu",
+        author: {
+          handle: localIdentityFixtures.connected_viewer.seededUser?.handle ?? "viewer",
+          displayName: "Viewer",
+          homeCity: "Los Angeles",
+          homeRegion: "CA"
+        },
+        primaryMedia: null,
+        stats: {
+          favoriteCount: 4,
+          commentCount: 1,
+          ratingCount: 2,
+          averageRating: 4.5
+        },
+        isFavorited: true
+      }
+    ]);
+
+    const app = await buildProfileRouteApp(localIdentityFixtures.connected_viewer.seededUser?.id);
+
+    const response = await app.inject({
+      method: "GET",
+      url: `/api/profiles/${localIdentityFixtures.connected_viewer.seededUser?.handle}/favorites?limit=1&offset=0`
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(listProfileFavoritesMock).toHaveBeenCalledWith({
+      profileHandle: localIdentityFixtures.connected_viewer.seededUser?.handle,
+      viewerId: localIdentityFixtures.connected_viewer.seededUser?.id,
+      limit: 1,
+      offset: 0
+    });
+    expect(response.json()).toEqual({
+      items: [
+        expect.objectContaining({
+          id: "adventure-1",
+          isFavorited: true
+        })
+      ],
+      paging: {
+        limit: 1,
+        offset: 0,
+        returned: 1
+      }
+    });
+
+    await app.close();
+  });
+
+  it("rejects favorites requests for another viewer handle", async () => {
+    const app = await buildProfileRouteApp(localIdentityFixtures.connected_viewer.seededUser?.id);
+
+    const response = await app.inject({
+      method: "GET",
+      url: "/api/profiles/another-user/favorites"
+    });
+
+    expect(response.statusCode).toBe(403);
+    expect(response.json()).toEqual({
+      error: "Forbidden."
+    });
+    expect(listProfileFavoritesMock).not.toHaveBeenCalled();
 
     await app.close();
   });


### PR DESCRIPTION
## Summary
- Add authenticated favorite save/unsave endpoints with idempotent behavior.
- Expose `GET /api/profiles/:handle/favorites` for the authenticated viewer and hydrate `isFavorited` on feed, detail, profile, and discover adventure cards.
- Update the server contract and add route/repository/app coverage for the new favorites flow.

## Testing
- Added targeted route and repository tests for favorite mutations, profile favorites access control, and viewer-scoped `isFavorited` hydration.
- Added app-level coverage for feed, detail, profile, and discover responses.
- Ran the focused favorites-related Vitest suites and typecheck successfully; full repo test run still has unrelated pre-existing env/script failures outside this slice.